### PR TITLE
Setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,16 +15,33 @@ The original everware team consists of [@OmeGak](https://github.com/omegak), [@i
 
 ## Testing
 
-In order to test `everware`, you can
+In order to test `everware`, you have to:
 
- - Install the newest git version of Jupyterhub: https://github.com/jupyter/jupyterhub
+ - Install the newest git version of `jupyterhub`: https://github.com/jupyter/jupyterhub. Double check with their [README.md](https://github.com/jupyter/jupyterhub/blob/master/README.md)
+```
+    sudo apt-get install npm nodejs-legacy
+    sudo npm install -g configurable-http-proxy
+    git clone https://github.com/jupyter/jupyterhub.git
+    cd jupyterhub
+    pip install -r dev-requirements.txt -e .
+```
+ - Install the newest git version of `dockerspawner`: https://github.com/jupyter/dockerspawner. Double check with their [README.md](https://github.com/jupyter/dockerspawner/blob/master/README.md)
+```
+    git clone https://github.com/jupyter/dockerspawner.git
+    cd dockerspawner
+    pip install -e.
+```
  - Create a Github OAuth application with URL `http://localhost:8000/` and callback URL `http://localhost:8000/hub/oauth_callback`
  - Clone this repo
+```
+    git clone https://github.com/everware/everware
+    cd everware
+```
  - Enter you OAuth information into `env.sh` and source it
  - Run
 
 ```
-    $ pip3 install --user .
-    $ jupyterhub
+    pip3 install --user .
+    jupyterhub
 ```
 

--- a/README.md
+++ b/README.md
@@ -31,15 +31,14 @@ In order to test `everware`, you have to:
     cd dockerspawner
     pip install -e.
 ```
- - Create a Github OAuth application with URL `http://localhost:8000/` and callback URL `http://localhost:8000/hub/oauth_callback`
  - Clone this repo
 ```
     git clone https://github.com/everware/everware
     cd everware
 ```
- - Enter you OAuth information into `env.sh` and source it
+ - Create a Github OAuth application with URL `http://localhost:8000/` and callback URL `http://localhost:8000/hub/oauth_callback`
+ - Enter you OAuth information into `env.sh` and `source env.sh`
  - Run
-
 ```
     pip3 install --user .
     jupyterhub

--- a/jupyterhub_config.py
+++ b/jupyterhub_config.py
@@ -25,6 +25,8 @@ c.GitHubOAuthenticator.client_secret = os.environ['GITHUB_CLIENT_SECRET']
 c.Spawner.tls = True
 c.Spawner.debug = True
 c.Spawner.http_timeout = 32
+c.Spawner.tls_assert_hostname = False
+c.Spawner.use_docker_client_env = True
 
 c.JupyterHub.data_files_path = 'share'
 c.JupyterHub.template_paths = ['share/static/html']

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,7 @@
+ipython[notebook]
+coveralls
+pytest-cov
+pytest
 jupyterhub
-requests
+dockerspawner
+GitPython==1.0.1


### PR DESCRIPTION
Went through the setup instruction in a clean virtualenv and found these additions useful.

I also needed to modify `jupyterhub_config.py` unsure if this is just for `boot2docker` though.

The `requirements.txt` is a bit excessive now. We _need_ `GitPython` and part of `ipython` to get the `puplic_ips()` method we use in the config file. The rest is "dev" stuff.
