### PR TITLE
Remove the need to store the user URL

### DIFF
--- a/everware/homehandler.py
+++ b/everware/homehandler.py
@@ -1,7 +1,9 @@
 
-from tornado import gen
-from jupyterhub.handlers.pages import web, BaseHandler
+from tornado import gen, web
+
+from jupyterhub.handlers.pages import BaseHandler
 from IPython.html.utils import url_path_join
+
 
 class HomeHandler(BaseHandler):
     """Render the user's home page."""
@@ -13,6 +15,7 @@ class HomeHandler(BaseHandler):
         )
         self.finish(html)
 
+    @web.authenticated
     @gen.coroutine
     def post(self):
         data = {}
@@ -32,5 +35,4 @@ class HomeHandler(BaseHandler):
             yield self.spawn_single_user(user)
 
         self.redirect(url_path_join(self.hub.server.base_url, user.server.base_url))
-
 

--- a/everware/homehandler.py
+++ b/everware/homehandler.py
@@ -25,7 +25,6 @@ class HomeHandler(BaseHandler):
         repo_url = data['repourl']
         user = self.get_current_user()
         user.last_repo_url = repo_url
-        self.db.commit()
 
         already_running = False
         if user.spawner:

--- a/jupyterhub_config.py
+++ b/jupyterhub_config.py
@@ -25,6 +25,7 @@ c.GitHubOAuthenticator.client_secret = os.environ['GITHUB_CLIENT_SECRET']
 c.Spawner.tls = True
 c.Spawner.debug = True
 c.Spawner.http_timeout = 32
+c.Spawner.remove_containers = True
 c.Spawner.tls_assert_hostname = False
 c.Spawner.use_docker_client_env = True
 


### PR DESCRIPTION
By stopping and removing the containers when the hub shutsdown we remove the need to keep the URL around.

We go back to having one container per user, so the name of the container is simpler. `get_container` now works with `container_id` which is stored in `get/load_state()`.

Don't remember why I originally added `gen.with_timeout(timedelta(30)` but I think we don't need it.

Added the `@web.authenticated` decorator
