### PR TITLE
Add -beta and link back to the code

### DIFF
--- a/share/static/html/home.html
+++ b/share/static/html/home.html
@@ -17,6 +17,7 @@
           name="repourl"
           id="repo_input"
           tabindex="1"
+	  autofocus="autofocus"
           placeholder="URL of git repository"
         />
     </div>

--- a/share/static/html/home.html
+++ b/share/static/html/home.html
@@ -4,7 +4,7 @@
 
 <div id="login-main">
 <header class="jumbotron masthead">
-    <h1>everware</h1>
+    <h1>everware - beta</h1>
     <p>Run your notebooks in the cloud</p>
 </header>
 
@@ -34,7 +34,7 @@
 <footer class="footer">
   <div class="footer-inside">
     <div class="col-sm-10">
-        Powered by <a href="https://jupyter.org/">Jupyter</a> and <a href="https://www.docker.com/">Docker</a>
+        <a href="https://github.com/everware">Everware</a> powered by <a href="https://jupyter.org/">Jupyter</a> and <a href="https://www.docker.com/">Docker</a>
     </div>
     <p style="float: right;">Logged in as {{user.name}}</p>
   </div>

--- a/share/static/html/login.html
+++ b/share/static/html/login.html
@@ -7,7 +7,7 @@
 {% block login %}
 <div id="login-main">
 <header class="jumbotron masthead">
-    <h1>everware</h1>
+    <h1>everware - beta</h1>
     <p>Run your notebooks in the cloud</p>
 </header>
 
@@ -83,7 +83,7 @@
 <footer class="footer">
 <div class="container">
     <div class="col-sm-12">
-        Powered by <a href="https://jupyter.org/">Jupyter</a> and <a href="https://www.docker.com/">Docker</a>
+        <a href="https://github.com/everware">Everware</a> is powered by <a href="https://jupyter.org/">Jupyter</a> and <a href="https://www.docker.com/">Docker</a>
     </div>
 </div>
 </footer>

--- a/share/static/html/page.html
+++ b/share/static/html/page.html
@@ -80,7 +80,6 @@
   </div>
 </noscript>
 
-<!--
 <div id="header" class="navbar navbar-static-top">
   <div class="container">
   <span id="jupyterhub-logo" class="pull-left"><a href="{{base_url}}"><img src='{{static_url("images/jupyter.png") }}' alt='JupyterHub' class='jpy-logo' title='Home'/></a></span>
@@ -101,7 +100,6 @@
   {% endblock %}
   </div>
 </div>
--->
 
 {% block main %}
 {% endblock %}


### PR DESCRIPTION
Added "- beta" to the bits where we otherwise just have "everware" and added a link at the bottom linking back to the code.

Reenabled the header-bag which provides a Logout button. Also means we have a jupyter logo showing, which we could replace with an everware one once we have it. How much does it upset the style conscious people? There was some talk of having a "nicely styled" logout button :-/
