### PR TITLE
Support for direct linking to a repo

### DIFF
--- a/everware/homehandler.py
+++ b/everware/homehandler.py
@@ -12,6 +12,7 @@ class HomeHandler(BaseHandler):
     def get(self):
         html = self.render_template('home.html',
             user=self.get_current_user(),
+            repo_url=self.get_argument('repo_url', ''),
         )
         self.finish(html)
 

--- a/share/static/html/home.html
+++ b/share/static/html/home.html
@@ -18,6 +18,9 @@
           id="repo_input"
           tabindex="1"
           placeholder="URL of git repository"
+          {% if repo_url %}
+          value="{{repo_url}}"
+          {% endif %}
         />
     </div>
     <input

--- a/share/static/html/login.html
+++ b/share/static/html/login.html
@@ -16,7 +16,11 @@
 {{ custom_html }}
 {% elif login_service %}
 <div class="service-login">
+  {% if repo_url %}
+  <a class='btn btn-github btn-lg' href='oauth_login?repo_url={{repo_url}}'>
+  {% else %}
   <a class='btn btn-github btn-lg' href='oauth_login'>
+  {% endif %}
     Sign in with {{login_service}}
   </a>
 </div>


### PR DESCRIPTION
A link like this will now directly take you where you
want to go: http://localhost:8000/hub/login?repo_url=http://example.com

This contains two things:
1. use of the `state` parameter to verify the callback is being made by someone we sent
2. support for dragging `repo_url` around so we can pre-fill the text field in `home.html`

(1) we should use anyway and I plan to contribute it back to jupyter/oauth, seems like good practice to include a `state` parameter with which you can verify that someone you sent is making the callback.

(2) is a big ugly, but it works. I stop at pre-filling the text box with the URL and don't submit it directly to give the user a chance to review what they are about to do. This feels like the right thing to do.

I use `eval()` to get the string representation of the dict back into a `dict`, `eval()` feels dirty and dangerous ... here it is Ok I think because we sign the string that we later `eval()`. What could possibly go wrong ...
