### PR TITLE
Noisy git status

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ whitelist.txt
 *.swp
 *.log
 *.pid
+# created by installing dummyauth
+src/*


### PR DESCRIPTION
Ignore the `src/` subdirectory created by installing dummy authenticator
