### PR TITLE
Destroying a container takes time after logout

### DIFF
--- a/frontend_tests/test_happy_mp.py
+++ b/frontend_tests/test_happy_mp.py
@@ -19,7 +19,7 @@ else:
     DRIVER = "firefox"
 
 # Test matrix
-SCENARIOS = ["scenario_full", "scenario_short"]
+SCENARIOS = ["scenario_short", "scenario_full"]
 USERS = ["user1", "user2"]
 TIMEOUT = 250
 UPLOADDIR = os.environ['UPLOADDIR']


### PR DESCRIPTION
By running the short tests first we avoid the problem of having previous containers hanging around.
