### PR TITLE
Lower case usernames and 403 page

### DIFF
--- a/everware/authenticator.py
+++ b/everware/authenticator.py
@@ -154,7 +154,6 @@ class GitHubOAuthHandler(BaseHandler):
             else:
                 self.redirect(self.hub.server.base_url + '/home')
         else:
-            # todo: custom error page?
             raise web.HTTPError(403)
 
 
@@ -226,7 +225,7 @@ class GitHubOAuthenticator(Authenticator):
         resp = yield http_client.fetch(req)
         resp_json = json.loads(resp.body.decode('utf8', 'replace'))
         
-        username = resp_json["login"]
+        username = self.normalize_username(resp_json["login"])
         if self.whitelist and username not in self.whitelist:
             username = None
         raise gen.Return((username, access_token))
@@ -302,7 +301,7 @@ class BitbucketOAuthenticator(Authenticator):
         resp = yield http_client.fetch(req)
         resp_json = json.loads(resp.body.decode('utf8', 'replace'))
 
-        username = resp_json["username"]
+        username = self.normalize_username(resp_json["username"])
         whitelisted = yield self.check_whitelist(username, headers)
         if not whitelisted:
             username = None

--- a/everware/tests/conftest.py
+++ b/everware/tests/conftest.py
@@ -5,9 +5,10 @@ from .mocking import MockWareHub
 @fixture(scope='module')
 def app(request):
     app = MockWareHub.instance(log_level=logging.DEBUG)
-    app.start([])
+    app.start(['-f', 'everware/tests/mock_config.py'])
     def fin():
         MockWareHub.clear_instance()
         app.stop()
     request.addfinalizer(fin)
     return app
+

--- a/everware/tests/mock_config.py
+++ b/everware/tests/mock_config.py
@@ -1,0 +1,9 @@
+import os
+import everware
+import everware.tests.mocking
+
+c = get_config()
+
+c.JupyterHub.data_files_path = 'share'
+c.JupyterHub.template_paths = ['share/static/html']
+c.Authenticator.whitelist = set(['river'])

--- a/everware/tests/mocking.py
+++ b/everware/tests/mocking.py
@@ -7,13 +7,15 @@ from everware.authenticator import GitHubOAuthenticator
 from everware.authenticator import GitHubLoginHandler
 from everware.authenticator import GitHubOAuthHandler
 from everware.authenticator import WelcomeHandler
+from tornado import web
+
 
 
 class MockGitHubOAuthHandler(GitHubOAuthHandler):
     def post(self):
         self._mock_username = self.get_argument('username')
         self._mock_password = self.get_argument('password')
-
+        
         username, token = self.authenticator.authenticate(self)
 
         if username:
@@ -41,12 +43,13 @@ class MockGitHubOAuthenticator(GitHubOAuthenticator):
         username = handler._mock_username
         password = handler._mock_password
         if username != password:
-            return None
-
+            return None, None
+        
+        username = self.normalize_username(username)
         if self.whitelist and username not in self.whitelist:
-            return None
+            return None, None
 
-        return (handler._mock_username, '1234')
+        return (username, '1234')
 
     def get_handlers(self, app):
         # replace oauth callback handler with a mock

--- a/everware/tests/test_pages.py
+++ b/everware/tests/test_pages.py
@@ -26,3 +26,24 @@ def test_authed_user_bypasses_login(app):
     print(url)
     print(app.hub.server.base_url)
     assert r.url == ujoin(url, app.hub.server.base_url, 'home')
+
+def test_username_case(app):
+    # A logged in user should go straight to the control panel
+    cookies = app.login_user('River')
+    r = requests.get(public_url(app), cookies=cookies)
+    r.raise_for_status()
+    assert 'Logged in as river' in r.text
+
+def test_whitelist(app):
+    url = public_url(app)
+    r = requests.post(
+        ujoin(url, app.hub.server.base_url, 'oauth_callback'),
+        data={
+            'username': 'wrong',
+            'password': 'wrong'
+        }
+    )
+    assert r.status_code == 403
+    text = ('Your username is not whitelisted on this server. '
+            'Please contact the system administrator.')
+    assert text in r.text

--- a/share/static/html/403.html
+++ b/share/static/html/403.html
@@ -22,9 +22,9 @@ Everware
     <div class="col-sm-8">
       <h1> 403 Forbidden </h1>
       <p>
-      You are not in a whitelist of this server. Please, contact to system administator to gain access.
+      Your username is not whitelisted on this server. Please contact the system administrator.
       </p>
-      <a href="{{base_url}}" class="btn btn-primary">Title page</a>
+      <a href="{{base_url}}/login" class="btn btn-primary" id="title">Title page</a>
     </div>
   </div>
 </div>

--- a/share/static/html/403.html
+++ b/share/static/html/403.html
@@ -1,0 +1,40 @@
+{% extends "page.html" %}
+
+{% block title %}
+Everware
+{% endblock %}
+
+{% block stylesheet %}
+    <link rel="stylesheet" href="{{ static_url("css/style.min.css") }}" type="text/css"/>
+    <style type="text/css"></style>
+{% endblock %}
+
+{% block main %}
+
+<div id="login-main">
+<header class="jumbotron masthead" style="padding: 1px">
+    <h1 style="font-size: 55px">everware</h1>
+    <p style="font-size: 26px">Sharing is caring</p>
+</header>
+
+<div class="container">
+  <div class="row row-centered">
+    <div class="col-sm-8">
+      <h1> 403 Forbidden </h1>
+      <p>
+      You are not in a whitelist of this server. Please, contact to system administator to gain access.
+      </p>
+      <a href="{{base_url}}" class="btn btn-primary">Title page</a>
+    </div>
+  </div>
+</div>
+
+<footer class="footer">
+  <div class="footer-inside">
+    <div class="col-sm-8">
+        Powered by <a href="https://jupyter.org/">Jupyter</a> and <a href="https://www.docker.com/">Docker</a>
+    </div>
+  </div>
+</footer>
+
+{% endblock %}


### PR DESCRIPTION
Added `normalize_username` to authenticators (should solve #33) and simple 403 page for users, that are not in a whitelist.
