### PR TITLE
Basic branch/commits pointers support

### DIFF
--- a/build_tools/frontend_test_config.py
+++ b/build_tools/frontend_test_config.py
@@ -3,3 +3,4 @@ load_subconfig('etc/base_config.py')
 
 c.JupyterHub.authenticator_class = 'dummyauthenticator.DummyAuthenticator'
 c.Spawner.start_timeout = 50
+c.Spawner.http_timeout = 45 # docker sometimes doesn't show up for a while

--- a/build_tools/frontend_test_config.py
+++ b/build_tools/frontend_test_config.py
@@ -3,4 +3,4 @@ load_subconfig('etc/base_config.py')
 
 c.JupyterHub.authenticator_class = 'dummyauthenticator.DummyAuthenticator'
 c.Spawner.start_timeout = 50
-c.Spawner.http_timeout = 45 # docker sometimes doesn't show up for a while
+c.Spawner.http_timeout = 120 # docker sometimes doesn't show up for a while

--- a/everware/git_executor.py
+++ b/everware/git_executor.py
@@ -1,0 +1,93 @@
+import git
+import re
+from tornado import gen
+from concurrent.futures import ThreadPoolExecutor
+
+
+class GitExecutor:
+
+    def __init__(self, repo_url, tmp_dir):
+        self._repo_url = repo_url
+        self._repo_dir = tmp_dir
+        self._repo_pointer = None
+        if '@' in repo_url:
+            self._processed_repo_url, self._repo_pointer = repo_url.split('@')
+        else:
+            parts = re.match(
+                r'(^.+?://[^/]+/[^/]+/.+?)(?:/|$)(tree|commit)?(/[^/]+)?',
+                repo_url
+            )
+            if not parts:
+                raise ValueError('Incorrect repo url')
+            self._processed_repo_url = parts.group(1)
+            if parts.group(3):
+                self._repo_pointer = parts.group(3)[1:]
+        if self._processed_repo_url.startswith('https') and\
+                self._processed_repo_url.endswith('.git'):
+            self._processed_repo_url = self._processed_repo_url[:-4]
+        if not self._repo_pointer:
+            self._repo_pointer = 'HEAD'
+
+    _git_executor = None
+
+    @property
+    def git_executor(self):
+        """single global git executor"""
+        cls = self.__class__
+        if cls._git_executor is None:
+            cls._git_executor = ThreadPoolExecutor(20)
+        return cls._git_executor
+
+    _git_client = None
+
+    @property
+    def git_client(self):
+        """single global git client instance"""
+        cls = self.__class__
+        if cls._git_client is None:
+            cls._git_client = git.Git()
+        return cls._git_client
+
+    def _git(self, method, *args, **kwargs):
+        """wrapper for calling git methods
+
+        to be passed to ThreadPoolExecutor
+        """
+        m = getattr(self.git_client, method)
+        return m(*args, **kwargs)
+
+    def git(self, method, *args, **kwargs):
+        """Call a git method in a background thread
+
+        returns a Future
+        """
+        return self.git_executor.submit(self._git, method, *args, **kwargs)
+
+    @gen.coroutine
+    def exec(self):
+        yield self.git('clone', self._processed_repo_url, self._repo_dir)
+        repo = git.Repo(self._repo_dir)
+        repo.git.reset('--hard', self._repo_pointer)
+        self._repo_sha = repo.rev_parse('HEAD')
+        self._branch_name = repo.active_branch.name
+
+    @property
+    def escaped_repo_url(self):
+        repo_url = re.sub(r'^.+?://', '', self._processed_repo_url)
+        if repo_url.endswith('.git'):
+            repo_url = repo_url[:-4]
+        trans = str.maketrans(':/-.', "____")
+        repo_url = repo_url.translate(trans).lower()
+        return re.sub(r'_+', '_', repo_url)
+
+    @property
+    def processed_repo_url(self):
+        return self._processed_repo_url
+
+    @property
+    def repo_sha(self):
+        return self._repo_sha
+
+    @property
+    def branch_name(self):
+        return self._branch_name

--- a/everware/git_executor.py
+++ b/everware/git_executor.py
@@ -5,8 +5,13 @@ from concurrent.futures import ThreadPoolExecutor
 
 
 class GitExecutor:
-
     def __init__(self, repo_url, tmp_dir):
+        """parse repo_url to parts:
+        _processed: url to clone from
+        _repo_pointer: position to reset"""
+
+        if repo_url.startswith('git://'):
+            raise ValueError("git protocol isn't supported yet")
         self._repo_url = repo_url
         self._repo_dir = tmp_dir
         self._repo_pointer = None
@@ -18,18 +23,17 @@ class GitExecutor:
                 repo_url
             )
             if not parts:
-                raise ValueError('Incorrect repo url')
+                raise ValueError('Incorrect repository url')
             self._processed_repo_url = parts.group(1)
             if parts.group(3):
                 self._repo_pointer = parts.group(3)[1:]
-        if self._processed_repo_url.startswith('https') and\
-                self._processed_repo_url.endswith('.git'):
+        if (self._processed_repo_url.startswith('https') and
+            self._processed_repo_url.endswith('.git')):
             self._processed_repo_url = self._processed_repo_url[:-4]
         if not self._repo_pointer:
             self._repo_pointer = 'HEAD'
 
     _git_executor = None
-
     @property
     def git_executor(self):
         """single global git executor"""
@@ -39,7 +43,6 @@ class GitExecutor:
         return cls._git_executor
 
     _git_client = None
-
     @property
     def git_client(self):
         """single global git client instance"""

--- a/everware/home_handler.py
+++ b/everware/home_handler.py
@@ -131,6 +131,9 @@ class HomeHandler(BaseHandler):
             return
 
         branch_name = commit_sha = None
+        repo_url = ''
+        fork_exists = False
+        repository_changed = False
         if user.running:
             branch_name = user.spawner.branch_name
             commit_sha = user.spawner.commit_sha
@@ -161,11 +164,6 @@ class HomeHandler(BaseHandler):
                                         user.token,
                                     )
                 repository_changed = yield _repository_changed(user)
-        else:
-            repo_url = ''
-            fork_exists = False
-            repository_changed = False
-
 
         if hasattr(user, 'login_service'):
             loginservice = user.login_service

--- a/everware/home_handler.py
+++ b/everware/home_handler.py
@@ -66,7 +66,7 @@ def _repository_changed(user):
         setup = yield user.spawner.docker(
                 'exec_create',
                 container=user.spawner.container_id,
-                cmd="bash -c 'cd analysis/ && \
+                cmd="bash -c 'cd $JPY_WORKDIR && \
                      (git fetch --unshallow > /dev/null 2>&1; true) && \
                      git diff --name-only'",
                 )
@@ -82,7 +82,7 @@ def _repository_changed(user):
         return False
 
 @gen.coroutine
-def _push_github_repo(user, url, token):
+def _push_github_repo(user, url, commit_sha, branch_name, token):
     result = re.findall('^https://github.com/([^/]+)/([^/]+).*', url)
     if not result:
         raise ValueError('URL is not a github URL')
@@ -93,21 +93,23 @@ def _push_github_repo(user, url, token):
     out = yield user.spawner.docker(
             'exec_create',
             container=user.spawner.container_id,
-            cmd="bash -c 'cd analysis/ && \
+            cmd="bash -c 'cd $JPY_WORKDIR && \
                  git config --global user.email \"everware@everware.xyz\" && \
                  git config --global user.name \"Everware\" && \
                  (git fetch --unshallow; true) && \
                  git add . && \
                  git commit -m \"Update through everware\" && \
-                 (git remote add everware-fork {}; true) && \
-                 (git checkout -b everware; true) && \
-                 git push everware-fork everware'".format(fork_url),
+                 (git remote add everware-fork {fork_url}; true) && \
+                 git push -f everware-fork {branch_name}'".format(
+                    fork_url=fork_url,
+                    commit_sha=commit_sha,
+                    branch_name=branch_name
+                ),
             )
     response = yield user.spawner.docker(
             'exec_start',
             exec_id=out['Id'],
     )
-
 
 class HomeHandler(BaseHandler):
     """Render the user's home page."""
@@ -146,6 +148,8 @@ class HomeHandler(BaseHandler):
                     yield _push_github_repo(
                             user,
                             user.spawner.repo_url,
+                            commit_sha,
+                            branch_name,
                             user.token,
                         )
                     self.redirect('/hub/home')

--- a/everware/home_handler.py
+++ b/everware/home_handler.py
@@ -134,10 +134,10 @@ class HomeHandler(BaseHandler):
         repo_url = ''
         fork_exists = False
         repository_changed = False
-        if user.running:
+        if user.running and hasattr(user, 'login_service'):
             branch_name = user.spawner.branch_name
             commit_sha = user.spawner.commit_sha
-            if getattr(user, "login_service", "") == "github":
+            if user.login_service == "github":
                 if do_fork:
                     self.log.info('Will fork %s' % user.spawner.repo_url)
                     yield _fork_github_repo(

--- a/everware/spawner.py
+++ b/everware/spawner.py
@@ -114,7 +114,7 @@ class CustomDockerSpawner(DockerSpawner):
         
         the user might have submitted
         """
-        return self.git_executor.processed_repo_url
+        return getattr(self.git_executor, 'processed_repo_url', None)
 
     @property
     def form_repo_url(self):
@@ -288,10 +288,13 @@ class CustomDockerSpawner(DockerSpawner):
     def get_env(self):
         env = super(CustomDockerSpawner, self).get_env()
         env.update({
-            'JPY_GITHUBURL': self.repo_url,
-            'JPY_REPOPOINTER': self.commit_sha,
             'JPY_WORKDIR': '/notebooks'
         })
+        if self.repo_url:
+            env.update({
+                'JPY_GITHUBURL': self.repo_url,
+                'JPY_REPOPOINTER': self.commit_sha,
+            })
         return env
 
 

--- a/everware/spawner.py
+++ b/everware/spawner.py
@@ -21,13 +21,13 @@ from tornado.ioloop import IOLoop
 
 from escapism import escape
 
-import git
-
 from .image_handler import ImageHandler
 
 import ssl
 
 import json
+
+from .git_executor import GitExecutor
 
 ssl._create_default_https_context = ssl._create_unverified_context
 
@@ -38,6 +38,7 @@ class CustomDockerSpawner(DockerSpawner):
         self._is_building = False
         self._image_handler = ImageHandler()
         self._cur_waiter = None
+        self._git_executor = None
         super(CustomDockerSpawner, self).__init__(**kwargs)
 
 
@@ -81,39 +82,6 @@ class CustomDockerSpawner(DockerSpawner):
         else:
             return m(*args, **kwargs)
 
-    _git_executor = None
-    @property
-    def git_executor(self):
-        """single global git executor"""
-        cls = self.__class__
-        if cls._git_executor is None:
-            cls._git_executor = ThreadPoolExecutor(1)
-        return cls._git_executor
-
-    _git_client = None
-    @property
-    def git_client(self):
-        """single global git client instance"""
-        cls = self.__class__
-        if cls._git_client is None:
-            cls._git_client = git.Git()
-        return cls._git_client
-
-    def _git(self, method, *args, **kwargs):
-        """wrapper for calling git methods
-
-        to be passed to ThreadPoolExecutor
-        """
-        m = getattr(self.git_client, method)
-        return m(*args, **kwargs)
-
-    def git(self, method, *args, **kwargs):
-        """Call a git method in a background thread
-
-        returns a Future
-        """
-        return self.git_executor.submit(self._git, method, *args, **kwargs)
-
     def clear_state(self):
         state = super(CustomDockerSpawner, self).clear_state()
         self.container_id = ''
@@ -143,15 +111,19 @@ class CustomDockerSpawner(DockerSpawner):
 
     @property
     def repo_url(self):
-        return self.user_options.get('repo_url', '')
+        return getattr(
+            self._git_executor,
+            'processed_repo_url',
+            self.user_options.get('repo_url', '')
+        )
 
     @property
-    def escaped_repo_url(self):
-        trans = str.maketrans(':/-.', "____")
-        repo_url = self.repo_url.translate(trans).lower()
-        if repo_url.endswith('.git'):
-            repo_url = repo_url[:-4]
-        return re.sub("_+", "_", repo_url)
+    def branch_name(self):
+        return self._git_executor.branch_name
+
+    @property
+    def commit_sha(self):
+        return self._git_executor.repo_sha
 
     @property
     def container_name(self):
@@ -220,17 +192,16 @@ class CustomDockerSpawner(DockerSpawner):
                 return image_name
 
         tmp_dir = mkdtemp(suffix='-everware')
+        self._git_executor = GitExecutor(self.repo_url, tmp_dir)
         self._add_to_log('Cloning repository %s' % self.repo_url)
         self.log.info('Cloning repo %s' % self.repo_url)
-        yield self.git('clone', self.repo_url, tmp_dir)
+        yield self._git_executor.exec()
         # use git repo URL and HEAD commit sha to derive
         # the image name
-        repo = git.Repo(tmp_dir)
-        self.repo_sha = repo.rev_parse("HEAD")
 
         image_name = "everware/{}-{}".format(
-            self.escaped_repo_url,
-            self.repo_sha
+            self._git_executor.escaped_repo_url,
+            self._git_executor.repo_sha
         )
 
         self._add_to_log('Building image (%s)' % image_name)
@@ -308,7 +279,10 @@ class CustomDockerSpawner(DockerSpawner):
 
     def get_env(self):
         env = super(CustomDockerSpawner, self).get_env()
-        env.update({'JPY_GITHUBURL': self.repo_url})
+        env.update({
+            'JPY_GITHUBURL': self._git_executor.processed_repo_url,
+            'JPY_REPOPOINTER': self._git_executor.repo_sha
+        })
         return env
 
 

--- a/everware/spawner.py
+++ b/everware/spawner.py
@@ -114,8 +114,11 @@ class CustomDockerSpawner(DockerSpawner):
         return getattr(
             self._git_executor,
             'processed_repo_url',
-            self.user_options.get('repo_url', '')
         )
+
+    @property
+    def form_repo_url(self):
+        return self.user_options.get('repo_url', '')
 
     @property
     def branch_name(self):
@@ -182,8 +185,8 @@ class CustomDockerSpawner(DockerSpawner):
     @gen.coroutine
     def build_image(self):
         """download the repo and build a docker image if needed"""
-        if self.repo_url.startswith('docker:'):
-            image_name = self.repo_url.replace('docker:', '')
+        if self.form_repo_url.startswith('docker:'):
+            image_name = self.form_repo_url.replace('docker:', '')
             image = yield self.get_image(image_name)
             if image is None:
                 raise Exception('Image %s doesn\'t exist' % image_name)
@@ -192,7 +195,7 @@ class CustomDockerSpawner(DockerSpawner):
                 return image_name
 
         tmp_dir = mkdtemp(suffix='-everware')
-        self._git_executor = GitExecutor(self.repo_url, tmp_dir)
+        self._git_executor = GitExecutor(self.form_repo_url, tmp_dir)
         self._add_to_log('Cloning repository %s' % self.repo_url)
         self.log.info('Cloning repo %s' % self.repo_url)
         yield self._git_executor.exec()
@@ -281,7 +284,8 @@ class CustomDockerSpawner(DockerSpawner):
         env = super(CustomDockerSpawner, self).get_env()
         env.update({
             'JPY_GITHUBURL': self._git_executor.processed_repo_url,
-            'JPY_REPOPOINTER': self._git_executor.repo_sha
+            'JPY_REPOPOINTER': self._git_executor.repo_sha,
+            'JPY_WORKDIR': '/notebooks'
         })
         return env
 

--- a/everware/tests/test_repourl_parser.py
+++ b/everware/tests/test_repourl_parser.py
@@ -1,0 +1,40 @@
+from .. import git_executor
+
+def test_parser():
+    tests = [
+        (
+            'git://github.com/aladagemre/django-notification.git@2927346f4c513a217ac8ad076e494dd1adbf70e1',
+            'git://github.com/aladagemre/django-notification.git',
+            '2927346f4c513a217ac8ad076e494dd1adbf70e1'
+        ),
+        (
+            'https://github.com/USER/REPO/tree/BRANCH_OR_COMMIT/',
+            'https://github.com/USER/REPO',
+            'BRANCH_OR_COMMIT'
+        ),
+        (
+            'https://github.com/USER/REPO.git@BRANCH_OR_COMMIT',
+            'https://github.com/USER/REPO',
+            'BRANCH_OR_COMMIT'
+        ),
+        (
+            'https://github.com/astiunov/everware-dimuon-example/commit/e4912ae86178ba4e8f8de05513ccd6592d237233',
+            'https://github.com/astiunov/everware-dimuon-example',
+            'e4912ae86178ba4e8f8de05513ccd6592d237233',
+        ),
+        (
+            'https://github.com/everware/everware-dimuon-example/',
+            'https://github.com/everware/everware-dimuon-example',
+            'HEAD'
+        ),
+        (
+            'https://github.com/everware/everware.git',
+            'https://github.com/everware/everware',
+            'HEAD'
+        )
+    ]
+
+    for url, repo_url, repo_pointer in tests:
+        parser = git_executor.GitExecutor(url, '')
+        assert parser.processed_repo_url == repo_url, 'in url %s' % url
+        assert parser._repo_pointer == repo_pointer, 'in url %s' % url

--- a/everware/tests/test_repourl_parser.py
+++ b/everware/tests/test_repourl_parser.py
@@ -3,8 +3,8 @@ from .. import git_executor
 def test_parser():
     tests = [
         (
-            'git://github.com/aladagemre/django-notification.git@2927346f4c513a217ac8ad076e494dd1adbf70e1',
-            'git://github.com/aladagemre/django-notification.git',
+            'https://github.com/aladagemre/django-notification.git@2927346f4c513a217ac8ad076e494dd1adbf70e1',
+            'https://github.com/aladagemre/django-notification',
             '2927346f4c513a217ac8ad076e494dd1adbf70e1'
         ),
         (

--- a/share/static/html/home.html
+++ b/share/static/html/home.html
@@ -15,9 +15,12 @@ Everware
 <div class="container" style="margin-top: 3%;">
   <div class="row">
     <div class="text-center">
-      <p>You are currently logged in through <b>{{ login_service }}</b>.</p>
+      <p>You are currently logged in through <strong>{{ login_service }}</strong>.</p>
       {% if user.running %}
-      <p>Currently checked out repository: {{ repourl }}</p>
+      <p>
+        Currently checked out repository: {{ repourl }}<br>
+        You are on branch <strong>{{ branch_name }}</strong>, commit <strong>{{ commit_sha }}</strong>
+      </p>
           {% if fork_exists %}
           <p>You have a repository with the same name, which we can push to!</p>
               {% if repository_changed %}

--- a/share/static/html/spawn.html
+++ b/share/static/html/spawn.html
@@ -29,7 +29,7 @@ Everware
       Error: {{error_message}}
     </div>
     {% endif %}
-    <form enctype="multipart/form-data" id="spawn_form" action="{{base_url}}spawn" method="post" role="form">
+    <form enctype="multipart/form-data" id="spawn_form" action="{{base_url}}spawn" method="post" role="form" style="width: 50%">
       {{spawner_options_form | safe}}
       <br>
       <input type="submit" value="Spawn" class="btn btn-primary">
@@ -70,7 +70,7 @@ require(["jquery"], function ($) {
   // add bootstrap form-control class to inputs
   $("#spawn_form").find("input, select, textarea, button").addClass("form-control");
   function showError(message) {
-    $("#error_text").text(message);
+    $("#error_text").text("Error: " + message);
     $("#error_text").show();
   }
   $("#spawn_form").on('submit', function (event) {
@@ -79,7 +79,7 @@ require(["jquery"], function ($) {
       showError('You have to provide the URL to a git repository.');
       return false;
     } else if (repo_url.lastIndexOf('git://', 0) == 0) {
-      showError("git protocol isn't supported yet");
+      showError("git protocol isn't supported yet. Please use the HTTPS URL scheme");
       return false;
     }
   });

--- a/share/static/html/spawn.html
+++ b/share/static/html/spawn.html
@@ -12,21 +12,23 @@ Everware
 {% block main %}
 
 <div id="login-main">
-<header class="jumbotron masthead" style="padding: 1px">
+<header class="jumbotron masthead" style="padding: 1px; margin-bottom: 1%">
     <h1 style="font-size: 55px">everware</h1>
     <p style="font-size: 26px">Sharing is caring</p>
 </header>
 
 <div class="container">
-  <!--div class="row text-center">
-    <h1>Spawner options</h1>
-  </div-->
-  <div class="row col-sm-offset-2 col-sm-8">
-      {% if error_message %}
-        <p class="spawn-error-msg text-danger">
-          Error: {{error_message}}
-        </p>
-      {% endif %}
+  <div class="row text-center">
+    <div class="spawn-error-msg text-danger" id="error_text"
+    {% if not error_message %}
+    style="display: none;"
+    >
+    </div>
+    {% else %}
+    >
+      Error: {{error_message}}
+    </div>
+    {% endif %}
     <form enctype="multipart/form-data" id="spawn_form" action="{{base_url}}spawn" method="post" role="form">
       {{spawner_options_form | safe}}
       <br>
@@ -67,6 +69,20 @@ Everware
 require(["jquery"], function ($) {
   // add bootstrap form-control class to inputs
   $("#spawn_form").find("input, select, textarea, button").addClass("form-control");
+  function showError(message) {
+    $("#error_text").text(message);
+    $("#error_text").show();
+  }
+  $("#spawn_form").on('submit', function (event) {
+    var repo_url = $('#repository_input').val();
+    if (!repo_url) {
+      showError('You have to provide the URL to a git repository.');
+      return false;
+    } else if (repo_url.startsWith('git://')) {
+      showError("git protocol isn't supported yet");
+      return false;
+    }
+  });
 });
 </script>
 {% endblock %}

--- a/share/static/html/spawn.html
+++ b/share/static/html/spawn.html
@@ -78,7 +78,7 @@ require(["jquery"], function ($) {
     if (!repo_url) {
       showError('You have to provide the URL to a git repository.');
       return false;
-    } else if (repo_url.startsWith('git://')) {
+    } else if (repo_url.lastIndexOf('git://', 0) == 0) {
       showError("git protocol isn't supported yet");
       return false;
     }


### PR DESCRIPTION
The first approach to #96. Supports urls with @, and /commit or /tree notation (you can see some in tests). It actually does `git reset --hard` instead of `checkout`, so we haven't problem with detached head. To make this work docker's image should use `$JPY_REPOPOINTER` something like this: https://github.com/astiunov/everware-dimuon-example/blob/master/start.sh#L26 (I suppose it should be added to yandex/rep)
