### PR TITLE
Remove old containers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ before_install:
   - export UPLOADDIR=${HOME}/frontend-test-screenshots/${JHUB_VERSION}_${TRAVIS_PYTHON_VERSION}
   - make gistup
   - docker pull anaderi/rep-jupyterhub:latest  # to speed up image creation during tests
-  - docker pull betatim/everware_cern_analysis:31102015
+  - docker pull yandex/rep:0.6.4
   - docker pull busybox # to check handling of image with no jupyter inside
 
 install: 

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,6 @@ before_install:
   - export UPLOADDIR=${HOME}/frontend-test-screenshots/${JHUB_VERSION}_${TRAVIS_PYTHON_VERSION}
   - make gistup
   - docker pull anaderi/rep-jupyterhub:latest  # to speed up image creation during tests
-  - docker pull yandex/rep:0.6.4
   - docker pull busybox # to check handling of image with no jupyter inside
 
 install: 

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ before_install:
   - export UPLOADDIR=${HOME}/frontend-test-screenshots/${JHUB_VERSION}_${TRAVIS_PYTHON_VERSION}
   - make gistup
   - docker pull anaderi/rep-jupyterhub:latest  # to speed up image creation during tests
+  - docker pull betatim/everware_cern_analysis:31102015
   - docker pull busybox # to check handling of image with no jupyter inside
 
 install: 

--- a/build_tools/nonstop_frontend_test_config.py
+++ b/build_tools/nonstop_frontend_test_config.py
@@ -1,0 +1,7 @@
+c = get_config()
+load_subconfig('etc/base_config.py')
+
+c.JupyterHub.authenticator_class = 'dummyauthenticator.DummyAuthenticator'
+c.Spawner.start_timeout = 50
+c.Spawner.http_timeout = 120 # docker sometimes doesn't show up for a while
+c.Spawner.remove_containers = False

--- a/build_tools/test_frontend.sh
+++ b/build_tools/test_frontend.sh
@@ -28,8 +28,8 @@ fi
 echo "Start running frontend tests"
 if [ -z "$UPLOADDIR" ] ; then
 	echo "no UPLOADDIR defined"
-    pkill -f everware-server
-    pkill -f node
+    pkill everware-server
+    pkill node
 	exit 1
 fi
 [ -d $UPLOADDIR ] && rm -rf $UPLOADDIR/*
@@ -55,8 +55,8 @@ if [ -f $LOG ] && [ $FAIL -eq 1 ]; then
 fi
 
 rm old_cont new_cont
-pkill -f everware-server
-pkill -f node
+pkill everware-server
+pkill node
 if [ $FAIL -eq 1 ]; then
     exit $FAIL
 fi
@@ -68,6 +68,7 @@ docker run --name jupyter-user1 --rm busybox sh -c 'sleep 3600' &
 
 echo "Starting everware-server($NONSTOP_OPTS)"
 everware-server ${NONSTOP_OPTS} > $LOG 2>&1 &
+sleep 3
 
 if [[ `pgrep -f everware-server` == "" ]] ; then
     echo "Error starting (non stop)"
@@ -91,6 +92,6 @@ echo ">>> Frontend test client log"
 find $UPLOADDIR -name "*.log" | xargs cat
 echo "<<< Frontend test client log"
 
-pkill -f everware-server
-pkill -f node
+pkill everware-server
+pkill node
 exit $FAIL

--- a/build_tools/test_frontend.sh
+++ b/build_tools/test_frontend.sh
@@ -10,25 +10,26 @@ NPROC=2
 echo "In" `pwd`
 
 OPTS="-f build_tools/frontend_test_config.py --no-ssl --debug $1"
+NONSTOP_OPTS="-f build_tools/nonstop_frontend_test_config.py --no-ssl --debug $1"
 
 docker ps -a -q | sort >old_cont
 
 # Start a hub that our tests can interact with
 echo "Starting everware-server($OPTS)"
 everware-server ${OPTS} > $LOG 2>&1 &
-HUB_PID=$!
 sleep 3
 
-if [[ `pgrep -f everware-server` == "" ]] ; then 
+if [[ `pgrep -f everware-server` == "" ]] ; then
     echo "Error starting"
-    tail $LOG 
+    tail $LOG
     exit 1
 fi
 
 echo "Start running frontend tests"
-if [ -z "$UPLOADDIR" ] ; then 
-	echo "no UPLOADDIR defined" 
-	kill ${HUB_PID}
+if [ -z "$UPLOADDIR" ] ; then
+	echo "no UPLOADDIR defined"
+    pkill -f everware-server
+    pkill -f node
 	exit 1
 fi
 [ -d $UPLOADDIR ] && rm -rf $UPLOADDIR/*
@@ -43,11 +44,6 @@ fi
 
 ADDED_CONT=0
 
-# echo ">>>>>>> Checking sleep container"
-# docker ps -a -q | head -1 | xargs docker inspect
-# docker ps -a -q | head -1 | xargs docker logs
-# echo "<<<<<<< Done"
-
 docker ps -a -q | sort >new_cont
 diff old_cont new_cont || ADDED_CONT=1
 
@@ -60,10 +56,42 @@ if [ $ADDED_CONT -eq 1 ]; then
 fi
 
 rm old_cont new_cont
+pkill -f everware-server
+pkill -f node
+if [ $FAIL -eq 1 ]; then
+    exit $FAIL
+fi
+sleep 15
+
+# spawn container to substitute in tests
+echo "Spawning running container"
+docker run --name jupyter-user1 --rm busybox sh -c 'sleep 3600' &
+
+echo "Starting everware-server($NONSTOP_OPTS)"
+everware-server ${NONSTOP_OPTS} > $LOG 2>&1 &
+
+if [[ `pgrep -f everware-server` == "" ]] ; then
+    echo "Error starting (non stop)"
+    tail $LOG
+    exit 1
+fi
+
+sleep 3
+export NOT_REMOVE=1
+
+nose2 -v -N $NPROC --start-dir=frontend_tests || FAIL=1
+
+if [ -f $LOG ]; then
+    echo ">>> Frontend test hub log (not remove containers):"
+    cat $LOG
+    echo "<<< Frontend test hub log (not remove containers):"
+fi
+
 
 echo ">>> Frontend test client log"
 find $UPLOADDIR -name "*.log" | xargs cat
 echo "<<< Frontend test client log"
 
-kill ${HUB_PID}
+pkill -f everware-server
+pkill -f node
 exit $FAIL

--- a/build_tools/test_frontend.sh
+++ b/build_tools/test_frontend.sh
@@ -34,14 +34,6 @@ if [ -z "$UPLOADDIR" ] ; then
 fi
 [ -d $UPLOADDIR ] && rm -rf $UPLOADDIR/*
 nose2 -v -N $NPROC --start-dir=frontend_tests || FAIL=1
-
-if [ -f $LOG ]; then
-    echo ">>> Frontend test hub log:"
-    cat $LOG
-    echo "<<< Frontend test hub log:"
-    docker ps -a
-fi
-
 ADDED_CONT=0
 
 docker ps -a -q | sort >new_cont
@@ -55,13 +47,20 @@ if [ $ADDED_CONT -eq 1 ]; then
     cat new_cont
 fi
 
+if [ -f $LOG ] && [ $FAIL -eq 1 ]; then
+    echo ">>> Frontend test hub log:"
+    cat $LOG
+    echo "<<< Frontend test hub log:"
+    docker ps -a
+fi
+
 rm old_cont new_cont
 pkill -f everware-server
 pkill -f node
 if [ $FAIL -eq 1 ]; then
     exit $FAIL
 fi
-sleep 15
+sleep 30
 
 # spawn container to substitute in tests
 echo "Spawning running container"
@@ -81,7 +80,7 @@ export NOT_REMOVE=1
 
 nose2 -v -N $NPROC --start-dir=frontend_tests || FAIL=1
 
-if [ -f $LOG ]; then
+if [ -f $LOG ] && [ $FAIL -eq 1 ]; then
     echo ">>> Frontend test hub log (not remove containers):"
     cat $LOG
     echo "<<< Frontend test hub log (not remove containers):"

--- a/everware/spawner.py
+++ b/everware/spawner.py
@@ -130,6 +130,7 @@ class CustomDockerSpawner(DockerSpawner, GitMixin):
         self._is_building = False
         self._image_handler = ImageHandler()
         self._cur_waiter = None
+        self._is_empty = False
         super(CustomDockerSpawner, self).__init__(**kwargs)
 
 
@@ -219,6 +220,10 @@ class CustomDockerSpawner(DockerSpawner, GitMixin):
     @property
     def need_remove(self):
         return self.user_options.get('need_remove', True)
+
+    @property
+    def is_empty(self):
+        return self._is_empty
 
     @gen.coroutine
     def get_container(self):
@@ -341,6 +346,7 @@ class CustomDockerSpawner(DockerSpawner, GitMixin):
         self._user_log = []
         self._is_failed = False
         self._is_building = True
+        self._is_empty = False
         try:
             f = self.build_image()
             image_name = yield gen.with_timeout(
@@ -386,6 +392,7 @@ class CustomDockerSpawner(DockerSpawner, GitMixin):
 
         Consider using pause/unpause when docker-py adds support
         """
+        self._is_empty = True
         self.log.info(
             "Stopping container %s (id: %s)",
             self.container_name, self.container_id[:7])

--- a/everware/user_wait_handler.py
+++ b/everware/user_wait_handler.py
@@ -25,6 +25,9 @@ class UserSpawnHandler(BaseHandler):
                 is_running = yield current_user.spawner.is_running()
                 if not current_user.spawn_pending and not is_failed and is_running:
                     is_done = True
+                if current_user.spawner.is_empty and not is_failed:
+                    self.redirect(url_path_join(self.hub.server.base_url, 'home'))
+                    return
             else:
                 log_lines = []
             if is_log_request:

--- a/frontend_tests/happy_scenarios.py
+++ b/frontend_tests/happy_scenarios.py
@@ -55,7 +55,7 @@ def scenario_full(user):
     user.wait_for_element_present(By.ID, "stop")
     driver.find_element_by_id("stop").click()
     user.log("stop clicked")
-    user.wait_for_element_present(By.ID, "start")
+    user.wait_for_pattern_in_page(r"Start\s+My\s+Server")
     driver.find_element_by_id("logout").click()
     user.log("logout clicked")
 
@@ -92,7 +92,7 @@ def scenario_no_jupyter(user):
     user.wait_for_element_present(By.ID, "stop")
     driver.find_element_by_id("stop").click()
     user.log("stop clicked")
-    user.wait_for_element_present(By.ID, "start")
+    user.wait_for_pattern_in_page(r"Start\s+My\s+Server")
     driver.find_element_by_id("logout").click()
     user.log("logout clicked")
 

--- a/frontend_tests/nonstop_scenarios.py
+++ b/frontend_tests/nonstop_scenarios.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+from selenium.webdriver.common.by import By
+from selenium.webdriver.common.keys import Keys
+
+def get_files(driver):
+    elems = driver.find_elements_by_xpath('//span[@class="item_name"]')
+    files = [
+        elem.get_attribute('innerHTML')
+        for elem in elems
+    ]
+    return sorted(files)
+
+def scenario_simple(user):
+    driver = user.get_driver()
+    driver.get(user.base_url + "/hub/login")
+    user.log("login")
+    driver.find_element_by_id("username_input").clear()
+    driver.find_element_by_id("username_input").send_keys(user.login)
+    driver.find_element_by_id("password_input").clear()
+    driver.find_element_by_id("password_input").send_keys(user.password)
+    driver.find_element_by_id("login_submit").click()
+    user.wait_for_element_present(By.ID, "start")
+    driver.find_element_by_id("start").click()
+    user.wait_for_element_present(By.ID, "repository_input")
+    driver.find_element_by_id("repository_input").clear()
+    driver.find_element_by_id("repository_input").send_keys(user.repo)
+    driver.find_element_by_xpath("//input[@value='Spawn']").click()
+    user.log("spawn clicked")
+    user.wait_for_element_present(By.LINK_TEXT, "Control Panel")
+    old_files = get_files(driver)
+    driver.find_element_by_link_text("Control Panel").click()
+    user.wait_for_element_present(By.ID, "stop")
+    driver.find_element_by_id("stop").click()
+    user.log("stop clicked")
+    user.wait_for_pattern_in_page(r"Start\s+My\s+Server")
+
+    driver.find_element_by_id("start").click()
+    user.wait_for_element_present(By.ID, "repository_input")
+    driver.find_element_by_id("repository_input").clear()
+    driver.find_element_by_id("repository_input").send_keys(
+        'https://github.com/everware/everware-dimuon-example'
+    )
+    driver.find_element_by_xpath("//input[@value='Spawn']").click()
+    user.log("spawn clicked (second time)")
+    user.wait_for_element_present(By.LINK_TEXT, "Control Panel")
+    new_files = get_files(driver)
+
+    assert old_files != new_files, """It's an old container:
+    Old elems: %s, New elems: %s
+    """ % (' '.join(old_files), ' '.join(new_files))

--- a/frontend_tests/nonstop_scenarios.py
+++ b/frontend_tests/nonstop_scenarios.py
@@ -38,7 +38,7 @@ def scenario_simple(user):
     user.wait_for_element_present(By.ID, "repository_input")
     driver.find_element_by_id("repository_input").clear()
     driver.find_element_by_id("repository_input").send_keys(
-        'https://github.com/everware/everware-dimuon-example'
+        'https://github.com/betatim/everware-demo'
     )
     driver.find_element_by_xpath("//input[@value='Spawn']").click()
     user.log("spawn clicked (second time)")

--- a/frontend_tests/nonstop_scenarios.py
+++ b/frontend_tests/nonstop_scenarios.py
@@ -38,7 +38,7 @@ def scenario_simple(user):
     user.wait_for_element_present(By.ID, "repository_input")
     driver.find_element_by_id("repository_input").clear()
     driver.find_element_by_id("repository_input").send_keys(
-        'https://github.com/everware/everware-dimuon-example'
+        'https://github.com/everware/travis-test-repo'
     )
     driver.find_element_by_xpath("//input[@value='Spawn']").click()
     user.log("spawn clicked (second time)")

--- a/frontend_tests/nonstop_scenarios.py
+++ b/frontend_tests/nonstop_scenarios.py
@@ -38,7 +38,7 @@ def scenario_simple(user):
     user.wait_for_element_present(By.ID, "repository_input")
     driver.find_element_by_id("repository_input").clear()
     driver.find_element_by_id("repository_input").send_keys(
-        'https://github.com/betatim/everware-demo'
+        'https://github.com/everware/everware-dimuon-example'
     )
     driver.find_element_by_xpath("//input[@value='Spawn']").click()
     user.log("spawn clicked (second time)")

--- a/frontend_tests/test_generator.py
+++ b/frontend_tests/test_generator.py
@@ -6,6 +6,7 @@ import os
 import happy_scenarios as hs
 from selenium.common.exceptions import NoSuchElementException
 import traceback
+import re
 
 
 REPO = "https://github.com/everware/everware-cpp-example.git"
@@ -75,6 +76,15 @@ class User:
                 break
             time.sleep(1)
         else: assert False, "time out waiting for (%s, %s)" % (how, what)
+
+    def wait_for_pattern_in_page(self, pattern, timeout=TIMEOUT):
+        for i in range(timeout):
+            page_source = self.driver.page_source
+            if re.search(pattern, page_source):
+                break
+            time.sleep(1)
+        else:
+            assert False, "time out waiting for pattern %s" % pattern
 
 
     def is_element_present(self, how, what):

--- a/frontend_tests/test_generator.py
+++ b/frontend_tests/test_generator.py
@@ -4,6 +4,7 @@ import nose2
 import time
 import os
 import happy_scenarios as hs
+import nonstop_scenarios as ns
 from selenium.common.exceptions import NoSuchElementException
 import traceback
 import re
@@ -17,11 +18,17 @@ else:
     DRIVER = "firefox"
 
 # Test matrix
-SCENARIOS = [
-    hs.scenario_timeout, # need to be in beginning
-    hs.scenario_full, hs.scenario_short,
-    hs.scenario_no_jupyter, hs.scenario_no_dockerfile,
-]
+if os.environ.get('NOT_REMOVE'):
+    SCENARIOS = [
+        ns.scenario_simple,
+    ]
+else:
+    SCENARIOS = [
+        hs.scenario_timeout, # need to be in beginning
+        hs.scenario_full, hs.scenario_short,
+        hs.scenario_no_jupyter, hs.scenario_no_dockerfile,
+    ]
+
 USERS = ["user1", "user2"]
 TIMEOUT = 250
 UPLOADDIR = os.environ['UPLOADDIR']


### PR DESCRIPTION
First attempt to fix #116 and #109. There is the checkbox, which corresponds to removing an old container if such exists. It's checked by default. It's also "checked" if you use `?repourl` scheme. I use `force=True` in `remove_container`, so it should perfectly erase even running containers.

I also changed `stop` method from `dockerspawner` a little bit, because sometimes `dockerspawner` tries to stop an already destroyed container.
