### PR TITLE
fix image tag <none>

### DIFF
--- a/everware/spawner.py
+++ b/everware/spawner.py
@@ -185,6 +185,8 @@ class CustomDockerSpawner(DockerSpawner, GitMixin, EmailNotificator):
         else:
             tag_processor = lambda tag: tag.split(':')[0]
         for img in images:
+            if not img['RepoTags']:
+                continue
             tags = (tag_processor(tag) for tag in img['RepoTags'])
             if image_name in tags:
                 return img


### PR DESCRIPTION
If there are images with tag <none> (left from unsuccessful build), everware fails (during search for an image in system)