### PR TITLE
Backend improvements

### DIFF
--- a/build_tools/test_frontend.sh
+++ b/build_tools/test_frontend.sh
@@ -16,8 +16,8 @@ function kill_everware {
 }
 
 if [ -z "$UPLOADDIR" ] ; then
-	echo "no UPLOADDIR defined"
-	exit 1
+    echo "no UPLOADDIR defined"
+    exit 1
 fi
 [ -d "$UPLOADDIR" ] && rm -rf "$UPLOADDIR"/*
 
@@ -30,6 +30,9 @@ for run_type in "normal" "nonstop"; do
 
     for scenario in ${SCENARIOS}; do
         echo "Running scenario $scenario"
+        if [ "$scenario" = "scenario_default_dockerfile" ]; then
+            export DEFAULT_DOCKER_IMAGE="yandexdataschool/neurohack-jupyter:2016.12"
+        fi
         everware-server $RUN_OPTIONS > $LOG 2>&1 &
         sleep $WAIT_FOR_START
         if [[ -z `pgrep -f everware-server` ]] ; then
@@ -40,6 +43,7 @@ for run_type in "normal" "nonstop"; do
 
         export EVERWARE_MODULE=$run_type
         export EVERWARE_SCENARIO=$scenario
+
         nose2 -v -N $NPROC --start-dir=$TESTS_DIR || FAIL=1
         if [[ $FAIL -eq 1 ]]; then
             kill_everware

--- a/build_tools/test_frontend.sh
+++ b/build_tools/test_frontend.sh
@@ -31,7 +31,7 @@ for run_type in "normal" "nonstop"; do
     for scenario in ${SCENARIOS}; do
         echo "Running scenario $scenario"
         if [ "$scenario" = "scenario_default_dockerfile" ]; then
-            export DEFAULT_DOCKER_IMAGE="yandexdataschool/neurohack-jupyter:2016.12"
+            export DEFAULT_DOCKER_IMAGE="anaderi/rep-jupyterhub:latest"
         fi
         everware-server $RUN_OPTIONS > $LOG 2>&1 &
         sleep $WAIT_FOR_START

--- a/env.sh.orig
+++ b/env.sh.orig
@@ -4,3 +4,4 @@ export OAUTH_CALLBACK_URL="http://localhost:8000/hub/oauth_callback"
 export EVERWARE_WHITELIST="whitelist.txt"
 export EMAIL_SUPPORT_ADDR=
 export EMAIL_FROM_ADDR=
+export DEFAULT_DOCKER_IMAGE="yandexdataschool/neurohack-jupyter:2016.12"

--- a/etc/base_config.py
+++ b/etc/base_config.py
@@ -10,6 +10,7 @@ c.Spawner.tls = False
 c.Spawner.debug = True
 c.Spawner.start_timeout = 1000
 c.Spawner.http_timeout = 60
+c.Spawner.poll_interval = 5
 c.Spawner.remove_containers = True
 c.Spawner.tls_assert_hostname = False
 c.Spawner.use_docker_client_env = True

--- a/everware/git_processor.py
+++ b/everware/git_processor.py
@@ -3,6 +3,7 @@ import git
 from concurrent.futures import ThreadPoolExecutor
 from tornado import gen
 import os
+import os.path
 
 
 class GitMixin:
@@ -104,11 +105,13 @@ class GitMixin:
         self._repo_sha = repo.rev_parse('HEAD').hexsha
         self._branch_name = repo.active_branch.name
 
-        dockerfile_path = os.join(self._repo_dir, 'Dockerfile')
+        dockerfile_path = os.path.join(self._repo_dir, 'Dockerfile')
         if not os.path.isfile(dockerfile_path):
+            if not os.environ.get('DEFAULT_DOCKER_IMAGE'):
+                raise Exception('No dockerfile in repository')
             with open(dockerfile_path, 'w') as fout:
                 fout.writelines([
-                    'FROM everware/datascience-jupyter:latest\n',
+                    'FROM %s\n' % os.environ['DEFAULT_DOCKER_IMAGE'],
                     'MAINTAINER Alexander Tiunov <astiunov@yandex-team.ru>'
                 ])
             return False

--- a/everware/spawner.py
+++ b/everware/spawner.py
@@ -2,6 +2,7 @@ from tempfile import mkdtemp
 from datetime import timedelta
 from os.path import join as pjoin
 from shutil import rmtree
+from pprint import pformat
 
 from concurrent.futures import ThreadPoolExecutor
 
@@ -219,6 +220,33 @@ class CustomDockerSpawner(DockerSpawner, GitMixin, EmailNotificator):
         })
 
     @gen.coroutine
+    def wait_up(self):
+        # copied from jupyterhub, because if user's server didn't appear, it
+        # means that spawn was unsuccessful, need to set is_failed
+        try:
+            yield self.user.server.wait_up(http=True, timeout=self.http_timeout)
+            ip, port = yield from self.get_ip_and_port()
+            self.user.server.ip = ip
+            self.user.server.port = port
+            self._is_up = True
+        except TimeoutError:
+            self._is_failed = True
+            self._add_to_log('Server never showed up after {} seconds'.format(self.http_timeout))
+            self.log.info("{user}'s server never showed up after {timeout} seconds".format(
+                user=self.user.name,
+                timeout=self.http_timeout
+            ))
+            yield self.notify_about_fail("Http timeout limit %.3f exceeded" % self.http_timeout)
+            raise
+        except Exception as e:
+            self._is_failed = True
+            message = str(e)
+            self._add_to_log('Something went wrong during waiting for server. Error: %s' % message)
+            yield self.notify_about_fail(message)
+            raise e
+
+
+    @gen.coroutine
     def build_image(self):
         """download the repo and build a docker image if needed"""
         if self.form_repo_url.startswith('docker:'):
@@ -240,7 +268,7 @@ class CustomDockerSpawner(DockerSpawner, GitMixin, EmailNotificator):
             self.log.info('Cloning repo %s' % self.repo_url)
             dockerfile_exists = yield self.prepare_local_repo()
             if not dockerfile_exists:
-                self._add_to_log('No dockerfile. Use the default one')
+                self._add_to_log('No dockerfile. Use the default one %s' % os.environ['DEFAULT_DOCKER_IMAGE'])
 
             # use git repo URL and HEAD commit sha to derive
             # the image name
@@ -302,6 +330,7 @@ class CustomDockerSpawner(DockerSpawner, GitMixin, EmailNotificator):
             ip, port = yield from self.get_ip_and_port()
             self.user.server.ip = ip
             self.user.server.port = port
+            self._is_up = True
         except TimeoutError:
             self._is_failed = True
             self._add_to_log('Server never showed up after {} seconds'.format(self.http_timeout))
@@ -361,37 +390,13 @@ class CustomDockerSpawner(DockerSpawner, GitMixin, EmailNotificator):
             message = str(e)
             if message.startswith('Failed to get port'):
                 message = "Container doesn't have jupyter-singleuser inside"
-            elif 'Cannot locate specified Dockerfile' in message:
-                message = "Your repo doesn't include Dockerfile"
             self._add_to_log('Something went wrong during building. Error: %s' % message)
             yield self.notify_about_fail(message)
             raise e
         finally:
             self._is_building = False
 
-        # copied from jupyterhub, because if user's server didn't appear, it
-        # means that spawn was unsuccessful, need to set is_failed
-        try:
-            yield self.user.server.wait_up(http=True, timeout=self.http_timeout)
-            ip, port = yield from self.get_ip_and_port()
-            self.user.server.ip = ip
-            self.user.server.port = port
-            self._is_up = True
-        except TimeoutError:
-            self._is_failed = True
-            self._add_to_log('Server never showed up after {} seconds'.format(self.http_timeout))
-            self.log.info("{user}'s server never showed up after {timeout} seconds".format(
-                user=self.user.name,
-                timeout=self.http_timeout
-            ))
-            yield self.notify_about_fail("Http timeout limit %.3f exceeded" % self.http_timeout)
-            raise
-        except Exception as e:
-            self._is_failed = True
-            message = str(e)
-            self._add_to_log('Something went wrong during waiting for server. Error: %s' % message)
-            yield self.notify_about_fail(message)
-            raise e
+        yield self.wait_up()
 
 
     @gen.coroutine

--- a/frontend_tests/normal_scenarios.py
+++ b/frontend_tests/normal_scenarios.py
@@ -69,3 +69,18 @@ def scenario_no_dockerfile(user):
     user.wait_for_element_present(By.ID, "resist")
     user.log("correct, no dockerfile")
 
+
+def scenario_default_dockerfile(user):
+    driver = commons.login(user)
+    user.wait_for_element_present(By.ID, "start")
+    driver.find_element_by_id("start").click()
+    commons.fill_repo_info(driver, user, 'https://github.com/everware/runnable_examples')
+    user.log("spawn clicked")
+    user.wait_for_element_present(By.LINK_TEXT, "Control Panel")
+    driver.find_element_by_link_text("Control Panel").click()
+    user.wait_for_element_present(By.ID, "stop")
+    driver.find_element_by_id("stop").click()
+    user.log("stop clicked")
+    user.wait_for_pattern_in_page(r"Launch\s+a\s+notebook")
+    driver.find_element_by_id("logout").click()
+    user.log("logout clicked")

--- a/frontend_tests/test_generator.py
+++ b/frontend_tests/test_generator.py
@@ -15,6 +15,7 @@ SCENARIOS = [
     normal_scenarios.scenario_short,
     normal_scenarios.scenario_no_jupyter,
     normal_scenarios.scenario_no_dockerfile,
+    normal_scenarios.scenario_default_dockerfile, # should go after no_dockerfile
     nonstop_scenarios.scenario_simple
 ]
 
@@ -38,7 +39,6 @@ def run_scenario(username, scenario):
     try:
         scenario(user)
     except Exception as e:
-        print(user.get_driver().get_log('har'), file=sys.stderr)
         print(user.get_driver().get_log('browser'), file=sys.stderr)
         make_screenshot(user.driver, "{}-{}.png".format(username, scenario.__name__))
         raise


### PR DESCRIPTION
This pr improves repos' handling and containers' polling a bit:
1. If there is no Dockerfile in the repo, the default one is used. You can set it up in env.sh.
2. The poll interval is decreased, so jupyterhub faster finds out that container isn't running.
3. Added check (to `poll`) that there is an alive http server inside the container. If it's not, the container is useless for everware, because user will get 503 error in such case, so it should be removed. Possibly solves #177.