### PR TITLE
Better way to add and replace handlers

### DIFF
--- a/scripts/everware-server
+++ b/scripts/everware-server
@@ -17,6 +17,16 @@ class Everware(app.JupyterHub):
 
     def init_handlers(self):
         super().init_handlers()
+        self.replace_handlers(handlers_map)
+
+    def replace_handlers(self, handlers_map):
+        """Replace default handler classes with new ones.
+
+        Parameters
+        ----------
+        handlers_map : dict
+            Contains a mapping old_handler_class:new_handler_class.
+        """
         for i, cur_handler in enumerate(self.handlers):
             new_handler = handlers_map.get(cur_handler[1])
             if new_handler:
@@ -24,6 +34,20 @@ class Everware(app.JupyterHub):
                 cur_handler[1] = new_handler
                 self.handlers[i] = tuple(cur_handler)
 
+    def add_handlers(self, handlers):
+        """Add new handlers.
+
+        Parameters
+        ----------
+        handlers : iterable
+            Contains tuples representing handlers: (url, handler[, init_args]).
+        """
+        if self.handlers[-1][0] == '(.*)':
+            for handler in handlers:
+                self.handlers.insert(-1, handler)
+        else:
+            for handler in handlers:
+                self.handlers.append(handler)
 
 main = Everware.launch_instance
 

--- a/scripts/everware-server
+++ b/scripts/everware-server
@@ -4,6 +4,7 @@ import jupyterhub.handlers.base as base
 from jupyterhub import app
 from everware import SpawnHandler, UserSpawnHandler, HomeHandler
 import sys
+import warnings
 
 handlers_map = {
     pages.HomeHandler: HomeHandler,
@@ -27,12 +28,16 @@ class Everware(app.JupyterHub):
         handlers_map : dict
             Contains a mapping old_handler_class:new_handler_class.
         """
+        replacement_count = 0
         for i, cur_handler in enumerate(self.handlers):
             new_handler = handlers_map.get(cur_handler[1])
             if new_handler:
                 cur_handler = list(cur_handler)
                 cur_handler[1] = new_handler
                 self.handlers[i] = tuple(cur_handler)
+                replacement_count += 1
+        if replacement_count != len(handlers_map):
+            warnings.warn('Some handler replacements failed', RuntimeWarning)
 
     def add_handlers(self, handlers):
         """Add new handlers.

--- a/scripts/everware-server
+++ b/scripts/everware-server
@@ -7,43 +7,31 @@ import sys
 import warnings
 
 
-CUSTOM_HANDLERS = [
-    ('/hub/user/([^/]+)(/.*)?', UserSpawnHandler),
-    ('/hub/home', HomeHandler),
-    ('/hub/spawn', SpawnHandler)
-]
-
-
 class Everware(app.JupyterHub):
     name = 'everware'
 
+    custom_handlers = [
+        ('/hub/user/([^/]+)(/.*)?', UserSpawnHandler),
+        ('/hub/home', HomeHandler),
+        ('/hub/spawn', SpawnHandler)
+    ]
+
     def init_handlers(self):
         super().init_handlers()
-        self.add_handlers(CUSTOM_HANDLERS)
+        self.add_handlers(Everware.custom_handlers)
 
-    def add_handlers(self, new_handlers, replace_existing=True):
-        """Add new handlers.
-
-        Parameters
-        ----------
-        handlers : list-like
-            Contains tuples representing handlers: (url, handler[, init_args]).
-        replace_existing : bool, optional(True)
-            If True, old handlers will be overwritten by new ones on overlapping urls.
-        """
-        for index, handler in enumerate(self.handlers):
-            for new_index, new_handler in enumerate(new_handlers):
-                if handler[0] == new_handler[0]:
-                    if replace_existing:
-                        self.handlers[index] = new_handler
-                    new_handlers.pop(new_index)
-                    break
-        if self.handlers[-1][0] == '(.*)':
-            for handler in new_handlers:
+    def add_handlers(self, handlers, replace_existing=True):
+        existing_handler_indices = {handler[0]: i for i, handler in enumerate(self.handlers)}
+        for handler in handlers:
+            existing_handler_index = existing_handler_indices.get(handler[0])
+            if existing_handler_index is None:
+                # must be inserted before the pattern '(.*)', which is the last one
                 self.handlers.insert(-1, handler)
-        else:
-            for handler in new_handlers:
-                self.handlers.append(handler)
+            elif replace_existing:
+                self.handlers[existing_handler_index] = handler
+            else:
+                warnings.warn('Custom handler for url {} was not added'.format(handler[0]),
+                              RuntimeWarning)
 
 
 main = Everware.launch_instance

--- a/scripts/everware-server
+++ b/scripts/everware-server
@@ -6,11 +6,12 @@ from everware import SpawnHandler, UserSpawnHandler, HomeHandler
 import sys
 import warnings
 
-handlers_map = {
-    pages.HomeHandler: HomeHandler,
-    pages.SpawnHandler: SpawnHandler,
-    base.UserSpawnHandler: UserSpawnHandler
-}
+
+CUSTOM_HANDLERS = [
+    ('/hub/user/([^/]+)(/.*)?', UserSpawnHandler),
+    ('/hub/home', HomeHandler),
+    ('/hub/spawn', SpawnHandler)
+]
 
 
 class Everware(app.JupyterHub):
@@ -18,41 +19,32 @@ class Everware(app.JupyterHub):
 
     def init_handlers(self):
         super().init_handlers()
-        self.replace_handlers(handlers_map)
+        self.add_handlers(CUSTOM_HANDLERS)
 
-    def replace_handlers(self, handlers_map):
-        """Replace default handler classes with new ones.
-
-        Parameters
-        ----------
-        handlers_map : dict
-            Contains a mapping old_handler_class:new_handler_class.
-        """
-        replacement_count = 0
-        for i, cur_handler in enumerate(self.handlers):
-            new_handler = handlers_map.get(cur_handler[1])
-            if new_handler:
-                cur_handler = list(cur_handler)
-                cur_handler[1] = new_handler
-                self.handlers[i] = tuple(cur_handler)
-                replacement_count += 1
-        if replacement_count != len(handlers_map):
-            warnings.warn('Some handler replacements failed', RuntimeWarning)
-
-    def add_handlers(self, handlers):
+    def add_handlers(self, new_handlers, replace_existing=True):
         """Add new handlers.
 
         Parameters
         ----------
-        handlers : iterable
+        handlers : list-like
             Contains tuples representing handlers: (url, handler[, init_args]).
+        replace_existing : bool, optional(True)
+            If True, old handlers will be overwritten by new ones on overlapping urls.
         """
+        for index, handler in enumerate(self.handlers):
+            for new_index, new_handler in enumerate(new_handlers):
+                if handler[0] == new_handler[0]:
+                    if replace_existing:
+                        self.handlers[index] = new_handler
+                    new_handlers.pop(new_index)
+                    break
         if self.handlers[-1][0] == '(.*)':
-            for handler in handlers:
+            for handler in new_handlers:
                 self.handlers.insert(-1, handler)
         else:
-            for handler in handlers:
+            for handler in new_handlers:
                 self.handlers.append(handler)
+
 
 main = Everware.launch_instance
 


### PR DESCRIPTION
This PR solves these small problems:
1) replacement of default handlers with custom ones is done in a weird loop in the `init_handlers` method
2) currently we need to do bad looking stuff like `self.handlers.insert(-1, handler)` in order to add new handlers for new urls as soon as new handlers must be placed in the handlers list before the handler which matches any urls except for default ones.

Solution: I added two new methods which allow  to add and replace handlers conveniently.