### PR TITLE
Minor fixes

### DIFF
--- a/build_tools/test_frontend.sh
+++ b/build_tools/test_frontend.sh
@@ -7,7 +7,7 @@ LOG="/tmp/frontend_test_hub.log"
 NPROC=2
 TESTS_DIR="frontend_tests"
 WAIT_FOR_START=3
-WAIT_FOR_STOP=25
+WAIT_FOR_STOP=20
 
 function kill_everware {
     echo "Stopping everware"
@@ -16,6 +16,7 @@ function kill_everware {
     if [[ ! -z `pgrep -f everware-server` ]] ; then
         echo "Fail to stop with sigterm, killing"
         pkill -KILL -f everware-server
+        sleep $WAIT_FOR_STOP
     fi
 }
 

--- a/build_tools/test_frontend.sh
+++ b/build_tools/test_frontend.sh
@@ -13,6 +13,10 @@ function kill_everware {
     echo "Stopping everware"
     pkill -TERM -f everware-server
     sleep $WAIT_FOR_STOP
+    if [[ ! -z `pgrep -f everware-server` ]] ; then
+        echo "Fail to stop with sigterm, killing"
+        pkill -KILL -f everware-server
+    fi
 }
 
 if [ -z "$UPLOADDIR" ] ; then

--- a/everware/image_handler.py
+++ b/everware/image_handler.py
@@ -42,8 +42,8 @@ class ImageMutex():
         return value
 
     def __enter__(self):
-        if self._exception is not None:
-            raise self._exception
+        # if self._exception is not None:
+        #     raise self._exception
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):

--- a/everware/spawner.py
+++ b/everware/spawner.py
@@ -226,7 +226,7 @@ class CustomDockerSpawner(DockerSpawner, GitMixin, EmailNotificator):
         # means that spawn was unsuccessful, need to set is_failed
         try:
             yield self.user.server.wait_up(http=True, timeout=self.http_timeout)
-            ip, port = yield from self.get_ip_and_port()
+            ip, port = yield self.get_ip_and_port()
             self.user.server.ip = ip
             self.user.server.port = port
             self._is_up = True

--- a/frontend_tests/normal_scenarios.py
+++ b/frontend_tests/normal_scenarios.py
@@ -55,9 +55,6 @@ def scenario_timeout(user):
     user.log('correct, timeout happened')
     driver.find_element_by_id("resist").click()
     user.log("resist clicked")
-    commons.fill_repo_info(driver, user, 'https://github.com/everware/test_long_creation')
-    user.log("spawn clicked (second try)")
-    user.wait_for_element_present(By.ID, "resist")
 
 
 def scenario_no_dockerfile(user):


### PR DESCRIPTION
Remove repeated `wait_up`, always try to build an image (there was a block in `__enter__`), return ip, port from swarm spawner as jupyterhub requires