### PR TITLE
Support TLS for BYOR

### DIFF
--- a/everware/byor_spawner.py
+++ b/everware/byor_spawner.py
@@ -9,30 +9,60 @@ from .spawner import CustomDockerSpawner
 
 
 class ByorDockerSpawner(CustomDockerSpawner):
+    byor_timeout = Int(20, min=1, config=True,
+                       help='Timeout for connection to BYOR Docker daemon').default_value
+
+    BYOR_OFF = 'off'  # byor was not requested by user
+    BYOR_ON = 'on'  # byor was requested by user and is ready to use
+    BYOR_NOT_READY = 'not_ready'  # byor was requested by user and is being prepared
+    BYOR_NOT_VALID = 'not_valid'  # byor was requested by user, but something went wrong
+    byor_statuses = [BYOR_OFF, BYOR_ON, BYOR_NOT_READY, BYOR_NOT_VALID]
+
     def __init__(self, **kwargs):
         CustomDockerSpawner.__init__(self, **kwargs)
-        self._byor_client = None
+        self._byor_config = self.make_empty_byor_config()
         if self.options_form == self._options_form_default():
             with open(pjoin(self.config['JupyterHub']['template_paths'][0],
                             '_byor_options_form.html')) as form:
                 ByorDockerSpawner.options_form = form.read()
 
+    @staticmethod
+    def make_empty_byor_config():
+        config = {
+            'status': 'off',
+            'client': None,
+            'ip': None,
+            'port': None,
+            'cert': None,
+            'key': None,
+            'ca': None
+        }
+        return config
+
     @property
     def client(self):
-        if self._byor_client is not None:
-            return self._byor_client
+        byor_client = self._byor_config['client']
+        if byor_client is not None:
+            return byor_client
         return super(ByorDockerSpawner, self).client
 
     @property
     def byor_is_used(self):
         return self.user_options.get('byor_is_needed', False)
 
+    @property
+    def byor_status(self):
+        return self._byor_config['status']
+
+    def _set_byor_status(self, status):
+        if status not in ByorDockerSpawner.byor_statuses:
+            message = 'value must be one of [{}]'.format(', '.join(ByorDockerSpawner.byor_status))
+            raise ValueError(message)
+        self._byor_config['status'] = status
+
     def _reset_byor(self):
         self.container_ip = str(self.__class__.container_ip)
-        self._byor_client = None
-
-    byor_timeout = Int(20, min=1, config=True,
-                       help='Timeout for connection to BYOR Docker daemon')
+        self._byor_config = self.make_empty_byor_config()
 
     def options_from_form(self, formdata):
         options = {}
@@ -50,31 +80,41 @@ class ByorDockerSpawner(CustomDockerSpawner):
         if not self.byor_is_used:
             self._reset_byor()
             return
+        self._set_byor_status(ByorDockerSpawner.BYOR_NOT_READY)
         byor_ip = self.user_options['byor_docker_ip']
         byor_port = self.user_options['byor_docker_port']
+        self._byor_config['ip'] = byor_ip
+        self._byor_config['port'] = byor_port
+        self.container_ip = byor_ip
         try:
             # version='auto' causes a connection to the daemon.
             # That's why the method must be a coroutine.
-            self._byor_client = docker.Client('{}:{}'.format(byor_ip, byor_port),
-                                              version='auto',
-                                              timeout=self.byor_timeout)
+            self._byor_config['client'] = docker.Client(
+                '{}:{}'.format(byor_ip, byor_port),
+                version='auto',
+                timeout=ByorDockerSpawner.byor_timeout
+            )
         except DockerException as e:
+            print(e)
             self._is_failed = True
             message = str(e)
             if 'ConnectTimeoutError' in message:
                 log_message = 'Connection to the Docker daemon took too long (> {} secs)'.format(
-                    self.byor_timeout
+                    ByorDockerSpawner.byor_timeout
                 )
-                notification_message = 'BYOR timeout limit {} exceeded'.format(self.byor_timeout)
+                notification_message = 'BYOR timeout limit {} exceeded'.format(
+                    ByorDockerSpawner.byor_timeout
+                )
             else:
                 log_message = "Failed to establish connection with the Docker daemon"
                 notification_message = log_message
             self._add_to_log(log_message, level=2)
             yield self.notify_about_fail(notification_message)
             self._is_building = False
+            self._set_byor_status(ByorDockerSpawner.BYOR_NOT_VALID)
             raise
-
-        self.container_ip = byor_ip
+        else:
+            self._set_byor_status(ByorDockerSpawner.BYOR_ON)
 
     @gen.coroutine
     def _prepare_for_start(self):

--- a/everware/byor_spawner.py
+++ b/everware/byor_spawner.py
@@ -148,7 +148,9 @@ class ByorDockerSpawner(CustomDockerSpawner):
                     self.byor_timeout
                 )
             else:
-                log_message = "Failed to establish connection with the Docker daemon"
+                log_message = "Failed to establish connection with the Docker daemon. Reason: {}".format(
+                    message
+                )
                 notification_message = log_message
             self._add_to_log(log_message, level=2)
             yield self.notify_about_fail(notification_message)
@@ -189,6 +191,7 @@ class ByorDockerSpawner(CustomDockerSpawner):
         return state
 
     def load_state(self, state):
+        self._byor_config = _make_empty_byor_config()
         byor_state = state.get('byor')
         if byor_state is not None:
             byor_config = self._byor_config

--- a/everware/byor_spawner.py
+++ b/everware/byor_spawner.py
@@ -65,13 +65,13 @@ class ByorDockerSpawner(CustomDockerSpawner):
         ----------
         content : dict
             Must contain keys "cert.pem", "key.pem" and "ca.pem"
-            mapped to bytes (the contents of the corresponding files).
+            mapped to contents of the corresponding files.
             (May contain anything else)
         """
         tls_dir = TemporaryDirectory(prefix='everware')
         missing_tls_files = []
         for filename in TLS_FILES:
-            with open(pjoin(tls_dir.name, filename), 'wb') as tls_file:
+            with open(pjoin(tls_dir.name, filename), 'w') as tls_file:
                 try:
                     tls_file.write(content[filename])
                 except KeyError:
@@ -93,7 +93,7 @@ class ByorDockerSpawner(CustomDockerSpawner):
                 byor_settings[field] = formdata.pop('byor_docker_' + field, None)[0].strip()
             byor_credentials = formdata.pop('byor_credentials__file', None)
             if byor_credentials is not None:
-                byor_files = {x['filename']: x['body'] for x in byor_credentials}
+                byor_files = {x['filename']: x['body'].decode('utf-8') for x in byor_credentials}
                 byor_settings['tls_dir'] = self._prepare_tls_dir(byor_files)
         options.update(
             super(ByorDockerSpawner, self).options_from_form(formdata)
@@ -183,7 +183,7 @@ class ByorDockerSpawner(CustomDockerSpawner):
         byor_state['tld_is_used'] = tls_dir is not None
         if byor_state['tld_is_used']:
             for filename in TLS_FILES:
-                with open(pjoin(tls_dir.name, filename), 'rb') as tls_file:
+                with open(pjoin(tls_dir.name, filename), encoding='utf-8') as tls_file:
                     byor_state[filename] = tls_file.read()
         state['byor'] = byor_state
         return state

--- a/everware/byor_spawner.py
+++ b/everware/byor_spawner.py
@@ -9,27 +9,39 @@ from tornado import gen
 from .spawner import CustomDockerSpawner
 
 
+__all__ = ['TLS_FILES', 'ByorDockerSpawner']
+
+
+TLS_FILES = ('cert.pem', 'key.pem', 'ca.pem')
+
+
+def _make_empty_byor_config():
+    config = {
+        'client': None,
+        'ip': None,
+        'port': None,
+        'tls_dir': None
+    }
+    return config
+
+
 class ByorDockerSpawner(CustomDockerSpawner):
+    """The class implements the concept \"Bring Your Own Resources\".
+
+    It allows to accept optional information about the server where the user wants to
+    run all the stuff. Namely, information includes the IP-address and the port of a Docker-daemon.
+    The scenario where the daemon is protected via TLS is supported as well.
+    """
     byor_timeout = Int(20, min=1, config=True,
-                       help='Timeout for connection to BYOR Docker daemon').default_value
+                       help='Timeout for connection to BYOR Docker daemon')
 
     def __init__(self, **kwargs):
         CustomDockerSpawner.__init__(self, **kwargs)
-        self._byor_config = self.make_empty_byor_config()
+        self._byor_config = _make_empty_byor_config()
         if self.options_form == self._options_form_default():
             with open(pjoin(self.config['JupyterHub']['template_paths'][0],
                             '_byor_options_form.html')) as form:
                 ByorDockerSpawner.options_form = form.read()
-
-    @staticmethod
-    def make_empty_byor_config():
-        config = {
-            'client': None,
-            'ip': None,
-            'port': None,
-            'tls_dir': None
-        }
-        return config
 
     @property
     def client(self):
@@ -44,36 +56,70 @@ class ByorDockerSpawner(CustomDockerSpawner):
 
     def _reset_byor(self):
         self.container_ip = str(self.__class__.container_ip)
-        self._byor_config = self.make_empty_byor_config()
+        self._byor_config = _make_empty_byor_config()
+
+    def _prepare_tls_dir(self, content):
+        """Make a temporary directory containing the user's credentials.
+
+        Parameters
+        ----------
+        content : dict
+            Must contain keys "cert.pem", "key.pem" and "ca.pem"
+            mapped to bytes (the contents of the corresponding files).
+            (May contain anything else)
+        """
+        tls_dir = TemporaryDirectory(prefix='everware')
+        missing_tls_files = []
+        for filename in TLS_FILES:
+            with open(pjoin(tls_dir.name, filename), 'wb') as tls_file:
+                try:
+                    tls_file.write(content[filename])
+                except KeyError:
+                    missing_tls_files.append(filename)
+        if missing_tls_files:
+            message = 'Some files necessary for TLS are missing: {}'.format(
+                missing_tls_files
+            )
+            self._add_to_log(message, level=2)
+            raise ValueError(message)
+        return tls_dir
 
     def options_from_form(self, formdata):
         options = {}
-        options['byor_is_needed'] = formdata.pop('byor_is_needed', [''])[0].strip() == 'on'
+        options['byor_is_needed'] = formdata.pop('byor_is_needed', ['off'])[0].strip() == 'on'
         if options['byor_is_needed']:
             options['byor_settings'] = byor_settings = {}
             for field in ('ip', 'port'):
                 byor_settings[field] = formdata.pop('byor_docker_' + field, None)[0].strip()
-            byor_credentials = formdata.pop('byor_credentials__file', [''])
-            if byor_credentials != ['']:
+            byor_credentials = formdata.pop('byor_credentials__file', None)
+            if byor_credentials is not None:
                 byor_files = {x['filename']: x['body'] for x in byor_credentials}
-                missing_tls_files = []
-                byor_settings['tls_dir'] = tls_dir = TemporaryDirectory(prefix='everware')
-                for filename in ('cert.pem', 'key.pem', 'ca.pem'):
-                    with open(pjoin(tls_dir.name, filename), 'wb') as tls_file:
-                        try:
-                            tls_file.write(byor_files[filename])
-                        except KeyError:
-                            missing_tls_files.append(filename)
-                if missing_tls_files:
-                    message = 'Some files necessary for TLS are missing: {}'.format(
-                        missing_tls_files
-                    )
-                    self._add_to_log(message, level=2)
-                    raise ValueError(message)
+                byor_settings['tls_dir'] = self._prepare_tls_dir(byor_files)
         options.update(
             super(ByorDockerSpawner, self).options_from_form(formdata)
         )
         return options
+
+    @gen.coroutine
+    def _make_byor_docker_client(self):
+        tls_dir = self._byor_config['tls_dir']
+        if tls_dir is not None:
+            tls_config = docker.tls.TLSConfig(
+                client_cert=(pjoin(tls_dir.name, 'cert.pem'), pjoin(tls_dir.name, 'key.pem')),
+                ca_cert=pjoin(tls_dir.name, 'ca.pem'),
+                verify=True
+            )
+        else:
+            tls_config = None
+        # version='auto' causes a connection to the daemon.
+        # That's why the method must be a coroutine.
+        client = docker.Client(
+            '{}:{}'.format(self._byor_config['ip'], self._byor_config['port']),
+            version='auto',
+            timeout=self.byor_timeout,
+            tls=tls_config
+        )
+        return client
 
     @gen.coroutine
     def _configure_byor(self):
@@ -86,34 +132,17 @@ class ByorDockerSpawner(CustomDockerSpawner):
         byor_config.update(self.user_options['byor_settings'])
         self.container_ip = byor_config['ip']
 
-        tls_dir = byor_config['tls_dir']
-        if tls_dir is not None:
-            tls_config = docker.tls.TLSConfig(
-                client_cert=(pjoin(tls_dir.name, 'cert.pem'), pjoin(tls_dir.name, 'key.pem')),
-                ca_cert=pjoin(tls_dir.name, 'ca.pem'),
-                verify=True
-            )
-        else:
-            tls_config = None
-
         try:
-            # version='auto' causes a connection to the daemon.
-            # That's why the method must be a coroutine.
-            byor_config['client'] = docker.Client(
-                '{}:{}'.format(byor_config['ip'], byor_config['port']),
-                version='auto',
-                timeout=ByorDockerSpawner.byor_timeout,
-                tls=tls_config
-            )
+            byor_config['client'] = yield self._make_byor_docker_client()
         except DockerException as e:
             self._is_failed = True
             message = str(e)
             if 'ConnectTimeoutError' in message:
                 log_message = 'Connection to the Docker daemon took too long (> {} secs)'.format(
-                    ByorDockerSpawner.byor_timeout
+                    self.byor_timeout
                 )
                 notification_message = 'BYOR timeout limit {} exceeded'.format(
-                    ByorDockerSpawner.byor_timeout
+                    self.byor_timeout
                 )
             else:
                 log_message = "Failed to establish connection with the Docker daemon"
@@ -133,3 +162,45 @@ class ByorDockerSpawner(CustomDockerSpawner):
         yield self._prepare_for_start()
         ip_port = yield self._start(image)
         return ip_port
+
+    def clear_state(self):
+        self._reset_byor()
+        super(ByorDockerSpawner, self).clear_state()
+
+    def get_state(self):
+        state = super(ByorDockerSpawner, self).get_state()
+        if not self.byor_is_used:
+            return state
+        byor_config = self._byor_config
+        byor_state = {
+            'ip': byor_config['ip'],
+            'port': byor_config['port']
+        }
+        tls_dir = byor_config['tls_dir']
+        byor_state['tld_is_used'] = tls_dir is not None
+        if byor_state['tld_is_used']:
+            for filename in TLS_FILES:
+                with open(pjoin(tls_dir.name, filename), 'rb') as tls_file:
+                    byor_state[filename] = tls_file.read()
+        state['byor'] = byor_state
+        return state
+
+    def load_state(self, state):
+        byor_state = state.get('byor')
+        if byor_state is None:
+            return
+        byor_config = self._byor_config
+        byor_config['ip'] = byor_state['ip']
+        byor_config['port'] = byor_state['port']
+        if byor_state['tld_is_used']:
+            byor_config['tls_dir'] = self._prepare_tls_dir(byor_state)
+        try:
+            byor_config['client'] = yield self._make_byor_docker_client()
+            self.container_ip = byor_state['ip']
+        except Exception as error:
+            message = 'Failed to create a docker client for user {}. Reason: {}'.format(
+                self.user.name, str(error)
+            )
+            self._add_to_log(message, level=1)
+            self._reset_byor()
+        super(ByorDockerSpawner, self).load_state(state)

--- a/everware/byor_spawner.py
+++ b/everware/byor_spawner.py
@@ -84,7 +84,6 @@ class ByorDockerSpawner(CustomDockerSpawner):
                     except KeyError:
                         missing_tls_files.append(filename)
                     byor_settings[filename[:-len('.pem')]] = temporary_file
-                print('DDD', missing_tls_files)
                 if missing_tls_files:
                     message = 'Some files necessary for TLS are missing: {}'.format(
                         missing_tls_files
@@ -122,7 +121,6 @@ class ByorDockerSpawner(CustomDockerSpawner):
                 tls=byor_config['tls']
             )
         except DockerException as e:
-            print(e)
             self._is_failed = True
             message = str(e)
             if 'ConnectTimeoutError' in message:

--- a/everware/user_spawn_handler.py
+++ b/everware/user_spawn_handler.py
@@ -88,7 +88,7 @@ class SpawnHandler(default_handlers.SpawnHandler):
             return
         form_options = {}
         for key, byte_list in self.request.body_arguments.items():
-            form_options[key] = [ bs.decode('utf8') for bs in byte_list ]
+            form_options[key] = [bs.decode('utf8') for bs in byte_list]
         for key, byte_list in self.request.files.items():
-            form_options["%s_file"%key] = byte_list
+            form_options["{}__file".format(key)] = byte_list
         self._spawn(user, form_options)

--- a/share/static/html/_byor_options_form.html
+++ b/share/static/html/_byor_options_form.html
@@ -81,5 +81,9 @@ $('#byor_is_needed').on('change', function() {
     class="mdl-textfield__input"/>
     <label class="mdl-textfield__label" for="byor_docker_port">port</label>
 </div>
+<br>If your Docker daemon is protected via TLS (which is recommended), attach corresponding
+<br>"cert.pem", "key.pem" and "ca.pem" files
+    (click <a href="https://docs.docker.com/engine/security/https/" target="_blank"> here</a> for details)
+<br><input type="file" name="byor_credentials" accept="application/x-pem-file" multiple>
 </div>
 </div>


### PR DESCRIPTION
Now TLS-protected Docker-daemons are supported: users can attach corresponding certificates when filling the form.

Technical note: the creation of a Docker-client in the case of BYOR should be done asynchronously since that's a pure network-operation. However, the method "load_state" must not be a Tornado-coroutine, so an attempt to restore the BYOR-Docker-client is done in a synchronous way. Taking into account the fact of rare usage of BYOR and that this synchronous call is done only when Everware itself starts, it's unlikely to cause any problems.